### PR TITLE
Update Droplets_QC_GE.smk

### DIFF
--- a/rules/Droplets_QC_GE.smk
+++ b/rules/Droplets_QC_GE.smk
@@ -70,7 +70,7 @@ rule QC_droplets_ge:
     threads:
         2
     resources:
-        mem_mb = (lambda wildcards, attempt: min(3072 + attempt * 3072, 20480)),
+        mem_mb = (lambda wildcards, attempt: min(20480 + attempt * 3072, 20480)),
         time_min = (lambda wildcards, attempt: min(attempt * 90, 200))
     shell:
         """


### PR DESCRIPTION
Raise reservation to avoid --attempt <= 8 being useless on this rule.